### PR TITLE
Fix logic bug when resuming script

### DIFF
--- a/scripts/maclog.py
+++ b/scripts/maclog.py
@@ -119,8 +119,8 @@ def main(argv):
 		fullseq = (line.split(",")[-1]).split("/")
 		if int(fullseq[0]) == year and int(fullseq[1]) > nextseq:
 			nextseq=int(fullseq[1])	# get sequence number of string
-			nextseq+=1
 	f.seek(0, 0) # seek back to start for subsequent access
+	nextseq+=1
 	print "Ready, awaiting Pi connection. To exit press Ctrl+C"
 	print "Note: Raspberry Pi's take a few minutes to boot up once switched on"
 	print " "


### PR DESCRIPTION
Next sequence is incremented every time a larger value is found. As a result, the script will duplicate sequence numbers if the highest one is even.

Example: If highest sequence is 2:
a) nextseq = 0
b) int(fullseq[1]) > nextseq - true
c) nextseq = 1
d) nextseq += 1, therefore nextseq = 2
e) int(fullseq[1]) > nextseq - false (2 is not greater than 2)
f) nextseq starts at 2, even though an entry exists for that sequence number

Instead the script should find the largest sequence and only increment once the entire file has been processed. Effectively the increment is moved outside the if block and for loop.
